### PR TITLE
Fix for CLN v24.05

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .direnv
 .envrc
 .mypy_cache
+.vscode/tasks.json

--- a/paythrough.py
+++ b/paythrough.py
@@ -20,12 +20,15 @@ def paythrough(plugin, bolt11, scid, msatoshi=None, label=None, riskfactor=None,
     All parameters after scid are identical to pay except exclude. These will
     all be forwarded to pay via this plugin.
     """
-    peers = plugin.rpc.listpeers()['peers']
-    channels = list(map(lambda peer: peer['channels'], peers))
-    channels = [item for sublist in channels for item in sublist]
-    channels = list(filter(lambda channel:
-                    channel['state'] == 'CHANNELD_NORMAL', channels))
+    # Fetch the list of channels from the RPC response
+    channels = plugin.rpc.listpeerchannels()['channels']
+
+    # Filter out only the channels that are in 'CHANNELD_NORMAL' state
+    channels = list(filter(lambda channel: channel['state'] == 'CHANNELD_NORMAL', channels))
+
+    # Get the length of the filtered channels
     channels_length = len(channels)
+    
     channels = list(filter(lambda channel: channel['short_channel_id'] != scid,
                     channels))
     

--- a/test_paythrough.py
+++ b/test_paythrough.py
@@ -27,7 +27,7 @@ def test_paythrough_starts(node_factory):
     l1.rpc.plugin_stop(plugin_path)
 
 def get_peer(node, id):
-    return node.rpc.listpeers(id)['peers'][0]['channels'][0]
+    return node.rpc.listpeerchannels(id)['channels'][0]
 
 def has_spendable(node, id):
     p = get_peer(node, id)
@@ -58,9 +58,9 @@ def test_paythrough_paythrough(capsys, node_factory):
     node_factory.join_nodes([l1, l3])
     node_factory.join_nodes([l1, l4])
 
-    scid12 = l1.rpc.listpeers(ids[1])['peers'][0]['channels'][0]['short_channel_id']
-    scid13 = l1.rpc.listpeers(ids[2])['peers'][0]['channels'][0]['short_channel_id']
-    scid14 = l1.rpc.listpeers(ids[3])['peers'][0]['channels'][0]['short_channel_id']
+    scid12 = l1.rpc.listpeerchannels(ids[1])['channels'][0]['short_channel_id']
+    scid13 = l1.rpc.listpeerchannels(ids[2])['channels'][0]['short_channel_id']
+    scid14 = l1.rpc.listpeerchannels(ids[3])['channels'][0]['short_channel_id']
 
     msats = round(5e7)
 


### PR DESCRIPTION
Replaced `listpeers` with `listpeerchannels`.